### PR TITLE
Posibilité de récupération de la photo de l'étudiant via esup-sgc plutôt que via Pégase

### DIFF
--- a/src/main/java/fr/univlorraine/mondossierweb/controllers/ConfigController.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/controllers/ConfigController.java
@@ -80,6 +80,7 @@ public class ConfigController {
 	private static final String PEGASE_TEST_PERIODE = "PEGASE_TEST_PERIODE";
 	private static final String PEGASE_TEST_APPRENANT = "PEGASE_TEST_APPRENANT";
 	private static final String PEGASE_TEST_CHEMIN = "PEGASE_TEST_CHEMIN";
+	private static final String ESUP_SGC_PHOTO_URL = "ESUP_SGC_PHOTO_URL";
 	private static final String SMTP_HOST = "SMTP_HOST";
 	private static final String SMTP_PORT = "SMTP_PORT";
 	private static final String SMTP_USERNAME = "SMTP_USERNAME";
@@ -240,6 +241,9 @@ public class ConfigController {
 	}
 	public String getPegaseTestChemin() {
 		return getStringValueForParameter(PEGASE_TEST_CHEMIN);
+	}
+	public String getEsupSgcPhotoUrl() {
+		return getStringValueForParameter(ESUP_SGC_PHOTO_URL);
 	}
 	public String getSmtpHost() {
 		return getStringValueForParameter(SMTP_HOST);

--- a/src/main/java/fr/univlorraine/mondossierweb/services/EsupSgcService.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/services/EsupSgcService.java
@@ -1,0 +1,67 @@
+package fr.univlorraine.mondossierweb.services;
+
+import fr.univlorraine.mondossierweb.controllers.ConfigController;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+@Slf4j
+public class EsupSgcService {
+
+    private transient String esupSgcPhotoUrl;
+
+    @Autowired
+    private transient ConfigController configController;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @PostConstruct
+    public void init() {
+        refreshParameters();
+    }
+
+    public void refreshParameters() {
+        esupSgcPhotoUrl = configController.getEsupSgcPhotoUrl();
+    }
+
+    public boolean isPhotoServiceOperational() {
+        return StringUtils.hasText(esupSgcPhotoUrl) && esupSgcPhotoUrl.contains("%s");
+    }
+
+    public ByteArrayInputStream getPhoto(String supannEtuId) {
+        if(!isPhotoServiceOperational()) {
+            return null;
+        }
+        byte[] photoData;
+        String url = String.format(esupSgcPhotoUrl, supannEtuId);
+        log.debug("GET PHOTO : {}", url);
+        try {
+            ResponseEntity<byte[]> response = restTemplate.getForEntity(url, byte[].class);
+            photoData = response.getBody();
+        } catch(HttpClientErrorException he) {
+            log.warn("Récupération de la photo de {} en erreur HTTP {}", supannEtuId, he.getStatusCode());
+            photoData = he.getResponseBodyAsByteArray();
+        } catch (Exception e) {
+            log.error("Une erreur est survenue lors de la récupération de la photo de {}", supannEtuId, e);
+            return null;
+        }
+        if(photoData == null || photoData.length == 0) {
+            return null;
+        } else {
+            return new ByteArrayInputStream(photoData);
+        }
+    }
+
+}

--- a/src/main/java/fr/univlorraine/mondossierweb/services/ExportService.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/services/ExportService.java
@@ -39,11 +39,17 @@ public class ExportService implements Serializable {
 	@Autowired
 	private transient PegaseService pegaseService;
 
+	@Autowired
+	private transient EsupSgcService esupSgcService;
+
 	
 	public ByteArrayInputStream getPhoto(String codeApprenant, String codeFormation, String codePeriode) {
-		File file = pegaseService.getPhoto(codeApprenant, codeFormation, codePeriode);
-
-		return getStream(file,codeApprenant, codeFormation, "Photo");
+		if(esupSgcService.isPhotoServiceOperational()) {
+			return esupSgcService.getPhoto(codeApprenant);
+		} else {
+			File file = pegaseService.getPhoto(codeApprenant, codeFormation, codePeriode);
+			return getStream(file, codeApprenant, codeFormation, "Photo");
+		}
 	}
 	
 	

--- a/src/main/java/fr/univlorraine/mondossierweb/ui/view/parametres/ParametresView.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/ui/view/parametres/ParametresView.java
@@ -46,14 +46,7 @@ import com.vaadin.flow.server.StreamResource;
 import fr.univlorraine.mondossierweb.model.app.entity.PreferencesApplication;
 import fr.univlorraine.mondossierweb.model.app.entity.PreferencesApplicationCategorie;
 import fr.univlorraine.mondossierweb.model.app.entity.PreferencesApplicationValeurs;
-import fr.univlorraine.mondossierweb.services.AccessTokenService;
-import fr.univlorraine.mondossierweb.services.AppUserDetailsService;
-import fr.univlorraine.mondossierweb.services.CasService;
-import fr.univlorraine.mondossierweb.services.CssService;
-import fr.univlorraine.mondossierweb.services.ParametrageService;
-import fr.univlorraine.mondossierweb.services.PegaseService;
-import fr.univlorraine.mondossierweb.services.PreferencesService;
-import fr.univlorraine.mondossierweb.services.SecurityService;
+import fr.univlorraine.mondossierweb.services.*;
 import fr.univlorraine.mondossierweb.ui.component.Card;
 import fr.univlorraine.mondossierweb.ui.component.KeyValuesLayout;
 import fr.univlorraine.mondossierweb.ui.component.ValuesLayout;
@@ -100,6 +93,7 @@ public class ParametresView extends Div implements HasDynamicTitle, HasHeader, L
 	private static final Integer PEGASE_ACCESS_TOKEN_ID = 2;
 	private static final Integer PEGASE_API_ID = 3;
 	private static final Integer PEGASE_PARAM = 4;
+	private static final Integer ESUP_SGC_PARAM = 11;
 	private static final Integer ADMIN_PARAM = 8;
 	private static final Integer SMTP_PARAM = 9;
 	private static final Integer CSS_PARAM = 10;
@@ -138,6 +132,8 @@ public class ParametresView extends Div implements HasDynamicTitle, HasHeader, L
 	private HashMap<String,String> blobNames = new HashMap<> ();
 
 	private HashMap<String, Image> blobImages = new HashMap<> ();
+    @Autowired
+    private EsupSgcService esupSgcService;
 
 	@PostConstruct
 	private void init() {
@@ -473,6 +469,30 @@ public class ParametresView extends Div implements HasDynamicTitle, HasHeader, L
 		if(categorieId.equals(PEGASE_PARAM)) {
 			buttonSync.setText(getTranslation(PARAMETRES_BUTTON_SYNC));
 			buttonSync.addClickListener(e -> syncServiceConfig(PegaseService.class.getName(), "refreshPegaseParameters"));
+			layout.add(syncButtonLayout);
+		}
+
+		//S'il s'agit de la catégorie ESUP-SGC
+		if(categorieId.equals(ESUP_SGC_PARAM)) {
+			buttonTester.setText(getTranslation("parametres.button-tester-esupsgc"));
+			buttonTester.addClickListener(e -> {
+				// Maj des paramètres depuis la BDD
+				esupSgcService.refreshParameters();
+				try {					// teste service ESUP-SGC
+					if(esupSgcService.getPhoto(pegaseService.getCodeApprenantTest()) != null) {
+						Utils.notifierSucces(getTranslation("esupsgc.ok", pegaseService.getCodeApprenantTest()));
+					} else {
+						Utils.notifierAnomalie(getTranslation("esupsgc.error", pegaseService.getCodeApprenantTest()));
+					}
+				}catch(Exception ex) {
+					Utils.notifierAnomalie(getTranslation("esupsgc.error", pegaseService.getCodeApprenantTest()) + " : " + ex.getLocalizedMessage());
+				}
+			});
+			buttonTester.setEnabled(esupSgcService.isPhotoServiceOperational());
+			layout.add(testButtonLayout);
+
+			buttonSync.setText(getTranslation(PARAMETRES_BUTTON_SYNC));
+			buttonSync.addClickListener(e -> syncServiceConfig(EsupSgcService.class.getName(), REFRESH_PARAMETERS));
 			layout.add(syncButtonLayout);
 		}
 

--- a/src/main/resources/db/migration/V1.0.19__ajout_parametres_esup_sgc.sql
+++ b/src/main/resources/db/migration/V1.0.19__ajout_parametres_esup_sgc.sql
@@ -1,0 +1,23 @@
+-- --------------------------------------------------------
+
+--
+-- Ajout categorie et parametre ESUP-SGC
+--
+UPDATE preferences_application_categorie
+SET ordre = ordre + 1
+WHERE ordre > 6;
+
+INSERT INTO preferences_application_categorie (cat_id, cat_desc, ordre)
+VALUES ('11', 'Web-Service de récupération de photo via ESUP-SGC', '7');
+
+INSERT INTO preferences_application (pref_id, pref_desc, secret, valeur, cat_id, type_id, ordre)
+VALUES (
+	'ESUP_SGC_PHOTO_URL',
+	'Ex. : https://esup-sgc.example.org/wsrest/photo/%s/restrictedPhotoSupannEtuId?cardEtat=ENABLED',
+	NULL,
+	NULL,
+	'11',
+	'STRING',
+	1
+);
+

--- a/src/main/resources/i18n/messages-default.properties
+++ b/src/main/resources/i18n/messages-default.properties
@@ -95,6 +95,10 @@ error.accessdenied.help   = Si vous pensez qu'il s'agit d'une erreur, vous pouve
 error.routenotfound       = La page n'a pas \u00E9t\u00E9 trouv\u00E9e.
 error.unknown             = Les informations demand\u00E9es n'ont pas pu \u00EAtre r\u00E9cup\u00E9r\u00E9es.
 
+esupsgc.ok    = R\u00E9cup\u00E9ration de la photo de {0} effectu\u00E9e avec succ\u00E8s
+esupsgc.error = La photo de {0} n'a pas pu \u00EAtre r\u00E9cup\u00E9r\u00E9e
+
+
 etatcivil.title = \u00C9tat-civil
 
 identite.nomfamille = Nom de famille
@@ -172,6 +176,7 @@ parametres.button-enregistrer-parametres = Enregistrer
 parametres.button-sync                   = Synchroniser la configuration
 parametres.button-tester-accesstoken     = Tester la r\u00E9cup\u00E9ration de l'access token
 parametres.button-tester-api             = Tester APIs
+parametres.button-tester-esupsgc         = Tester la r\u00E9cup\u00E9ration photo depuis ESUP-SGC
 parametres.dialog-cleandb.button         = Supprimer
 parametres.dialog-cleandb.header         = Suppression des pr\u00E9f\u00E9rences utilisateurs
 parametres.dialog-cleandb.txt            = Cette action va supprimer toutes les pr\u00E9f\u00E9rences utilisateurs stock\u00E9es en base de donn\u00E9es. Confirmez-vous cette action ?


### PR DESCRIPTION
Hello,

Dans le même esprit que https://github.com/EsupPortail/esup-mdw/pull/55 on propose une implémentation permettant à esup-mdw-pegase de récupérer les photos d'un [esup-sgc](https://github.com/EsupPortail/esup-sgc) plutôt que celles proposées/envoyées en tant que pièce joint dans Pégase.

Fonctionnera à partir d'esup-sgc 3.3.0 qu'on va taguer d'ici peu : cette version permettra d'avoir la route type https://esup-sgc.example.org/wsrest/photo/%s/restrictedPhotoSupannEtuId qui permet de récupérer une photo non pas depuis un eppn mais depuis un supannEtuId (nécessaire ici).

Merci !
Vincent. 